### PR TITLE
Improve performance and best practices

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -93,7 +93,7 @@ impl<'a> Lexer<'a> {
                     let comment = self.read_while(|c| !Self::is_newline(c));
                     let n = self.input.next();
                     if let Some(n) = n {
-                        Some((SyntaxKind::COMMENT, comment + n.to_string().as_str()))
+                        Some((SyntaxKind::COMMENT, comment + &n.to_string()))
                     } else {
                         Some((SyntaxKind::COMMENT, comment))
                     }
@@ -101,29 +101,26 @@ impl<'a> Lexer<'a> {
                 (c, _) if Self::is_newline(c) => {
                     self.input.next();
                     self.line_type = None;
-                    Some((SyntaxKind::NEWLINE, c.to_string()))
+                    Some((SyntaxKind::NEWLINE, String::from(c)))
                 }
                 (';', Some(LineType::Header)) => Some((
                     SyntaxKind::SEMICOLON,
-                    self.input.next().unwrap().to_string(),
+                    String::from(self.input.next().unwrap()),
                 )),
                 ('(', Some(LineType::Header)) => {
                     let version = self
                         .read_while(|c| c != ')' && c != ';' && c != ' ' && !Self::is_newline(c));
                     let n = self.input.next();
                     if n == Some(')') {
-                        Some((
-                            SyntaxKind::VERSION,
-                            version + n.unwrap().to_string().as_str(),
-                        ))
+                        Some((SyntaxKind::VERSION, version + &n.unwrap().to_string()))
                     } else if let Some(n) = n {
-                        Some((SyntaxKind::ERROR, version + n.to_string().as_str()))
+                        Some((SyntaxKind::ERROR, version + &n.to_string()))
                     } else {
                         Some((SyntaxKind::ERROR, version))
                     }
                 }
                 ('=', Some(LineType::Header)) => {
-                    Some((SyntaxKind::EQUALS, self.input.next().unwrap().to_string()))
+                    Some((SyntaxKind::EQUALS, String::from(self.input.next().unwrap())))
                 }
                 (_, Some(LineType::Body)) => {
                     let detail = self.read_while(|c| !Self::is_newline(c));
@@ -138,9 +135,9 @@ impl<'a> Lexer<'a> {
                     let email = self.read_while(|c| c != '>' && c != ' ' && !Self::is_newline(c));
                     let n = self.input.next();
                     if n == Some('>') {
-                        Some((SyntaxKind::EMAIL, email + n.unwrap().to_string().as_str()))
+                        Some((SyntaxKind::EMAIL, email + &n.unwrap().to_string()))
                     } else if let Some(n) = n {
-                        Some((SyntaxKind::ERROR, email + n.to_string().as_str()))
+                        Some((SyntaxKind::ERROR, email + &n.to_string()))
                     } else {
                         Some((SyntaxKind::ERROR, email))
                     }
@@ -152,7 +149,7 @@ impl<'a> Lexer<'a> {
                 }
                 (_, _) => {
                     self.input.next();
-                    Some((SyntaxKind::ERROR, c.to_string()))
+                    Some((SyntaxKind::ERROR, String::from(c)))
                 }
             }
         } else {
@@ -291,10 +288,7 @@ mod tests {
                 .iter()
                 .map(|(kind, text)| (*kind, text.as_str()))
                 .collect::<Vec<_>>(),
-            vec![
-                (INDENT, " -- "),
-                (TEXT, "Name123-test"),
-            ]
+            vec![(INDENT, " -- "), (TEXT, "Name123-test"),]
         );
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -835,7 +835,7 @@ impl ChangeLog {
             root: self.0.clone(),
             package,
             version,
-            distributions: Some(vec!["UNRELEASED".into()]),
+            distributions: Some(vec![crate::UNRELEASED.into()]),
             urgency: Some(Urgency::default()),
             maintainer: crate::get_maintainer(),
             timestamp: Some(chrono::Utc::now().into()),
@@ -2480,10 +2480,19 @@ lintian-brush (0.35) UNRELEASED; urgency=medium
         .unwrap();
 
         // Test popping existing lines
-        assert_eq!(entry.pop_change_line(), Some("* Added new feature.".to_string()));
-        assert_eq!(entry.pop_change_line(), Some("* Fixed bug #123.".to_string()));
-        assert_eq!(entry.pop_change_line(), Some("* New upstream release.".to_string()));
-        
+        assert_eq!(
+            entry.pop_change_line(),
+            Some("* Added new feature.".to_string())
+        );
+        assert_eq!(
+            entry.pop_change_line(),
+            Some("* Fixed bug #123.".to_string())
+        );
+        assert_eq!(
+            entry.pop_change_line(),
+            Some("* New upstream release.".to_string())
+        );
+
         // Test popping from empty entry
         assert_eq!(entry.pop_change_line(), None);
     }
@@ -2529,7 +2538,7 @@ lintian-brush (0.35) UNRELEASED; urgency=medium
         .unwrap();
 
         entry.append_change_line("* Fixed bug #456.");
-        
+
         assert_eq!(
             entry.to_string(),
             r#"breezy (3.3.4-1) unstable; urgency=low
@@ -2554,13 +2563,12 @@ lintian-brush (0.35) UNRELEASED; urgency=medium
         .unwrap();
 
         entry.append_change_line("");
-        
+
         let lines: Vec<String> = entry.change_lines().collect();
         // Empty lines are not returned by change_lines()
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0], "* New upstream release.".to_string());
     }
-
 
     #[test]
     fn test_changelog_write_to_path() {
@@ -2577,9 +2585,9 @@ lintian-brush (0.35) UNRELEASED; urgency=medium
 
         let temp_file = NamedTempFile::new().unwrap();
         let path = temp_file.path().to_path_buf();
-        
+
         changelog.write_to_path(&path).unwrap();
-        
+
         let contents = std::fs::read_to_string(&path).unwrap();
         assert_eq!(contents, changelog.to_string());
     }
@@ -2649,8 +2657,10 @@ breezy (3.3.3-1) unstable; urgency=low
 
         // Test setting maintainer
         entry.set_maintainer(("New Maintainer".into(), "new@example.com".into()));
-        
-        assert!(entry.to_string().contains("New Maintainer <new@example.com>"));
+
+        assert!(entry
+            .to_string()
+            .contains("New Maintainer <new@example.com>"));
     }
 
     #[test]
@@ -2666,7 +2676,9 @@ breezy (3.3.3-1) unstable; urgency=low
 
         // Test setting timestamp when it's missing
         entry.set_timestamp("Mon, 04 Sep 2023 18:13:45 -0500".into());
-        
-        assert!(entry.to_string().contains("Mon, 04 Sep 2023 18:13:45 -0500"));
+
+        assert!(entry
+            .to_string()
+            .contains("Mon, 04 Sep 2023 18:13:45 -0500"));
     }
 }

--- a/src/textwrap.rs
+++ b/src/textwrap.rs
@@ -16,15 +16,11 @@ pub const INITIAL_INDENT: &str = "* ";
 
 #[inline]
 fn can_break_word(line: &str, pos: usize) -> bool {
-    if let Some(_bugnp) = line.strip_prefix("Closes: #") {
-        if pos < line.find('#').unwrap() {
-            return false;
-        }
+    if line.starts_with("Closes: #") && pos < "Closes: ".len() {
+        return false;
     }
-    if let Some(_lpbugno) = line.strip_prefix("LP: #") {
-        if pos < line.find('#').unwrap() {
-            return false;
-        }
+    if line.starts_with("LP: #") && pos < "LP: ".len() {
+        return false;
     }
     line[pos..].starts_with(' ')
 }
@@ -42,7 +38,7 @@ mod can_break_word_tests {
     fn test_can_break_word_edge_cases() {
         // Test position at end of string
         assert!(!super::can_break_word("foo", 3));
-        
+
         // Test empty string
         assert!(!super::can_break_word("", 0));
     }
@@ -256,24 +252,24 @@ mod can_join_tests {
         // Test line ending with bracket
         assert!(!super::can_join("Some text]", "Uppercase text"));
         assert!(!super::can_join("Some text}", "Uppercase text"));
-        
+
         // Test line ending with period and uppercase next line
         assert!(super::can_join("End with period.", "Uppercase text"));
-        
+
         // Test line not ending with period and uppercase next line
         assert!(!super::can_join("No period", "Uppercase text"));
-        
+
         // Test line2 starting with bullet points
         assert!(!super::can_join("Some text", "  * bullet"));
         assert!(!super::can_join("Some text", "  - bullet"));
         assert!(!super::can_join("Some text", "  + bullet"));
-        
+
         // Test line1 ending with colon
         assert!(!super::can_join("Introduction:", "some text"));
-        
+
         // Test same indentation
         assert!(super::can_join("  same indent", "  can join"));
-        
+
         // Test empty lines
         assert!(super::can_join("", ""));
     }
@@ -472,7 +468,7 @@ mod rewrap_tests {
         let long = "x".repeat(100);
         assert_eq!(
             super::Error::MissingBulletPoint { line: long.clone() },
-            rewrap_change(&[long.as_str()], None).unwrap_err()
+            rewrap_change(&[&long], None).unwrap_err()
         );
     }
 


### PR DESCRIPTION
* Replace char.to_string() with String::from() in lexer for efficiency
* Eliminate unnecessary .clone() in release() function
* Add UNRELEASED constant to centralize magic strings
* Fix clippy warnings: collapsible if statements and io_other_error
* Improve error handling in can_break_word function
* Update documentation formatting for better readability