### PR TITLE
Preserve blank line after header when appending to empty entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "debian-changelog"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "debversion",
@@ -432,9 +432,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "debian-changelog"
 repository = "https://github.com/jelmer/debian-changelog-rs"
 description = "Parser for Debian changelog files"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1854,7 +1854,19 @@ impl Entry {
             .children()
             .filter(|n| n.kind() == ENTRY_BODY)
             .last()
-            .unwrap_or_else(|| self.0.children().next().unwrap());
+            .unwrap_or_else(|| {
+                // No ENTRY_BODY nodes exist. Insert after the EMPTY_LINE that follows
+                // the ENTRY_HEADER (if it exists), to preserve required blank line.
+                let children: Vec<_> = self.0.children().collect();
+                if children.len() >= 2
+                    && children[0].kind() == ENTRY_HEADER
+                    && children[1].kind() == EMPTY_LINE
+                {
+                    children[1].clone()
+                } else {
+                    children[0].clone()
+                }
+            });
 
         let syntax = SyntaxNode::new_root_mut(builder.finish()).into();
         self.0


### PR DESCRIPTION
Fix append_change_line() to insert after the first EMPTY_LINE node (when present) rather than after the ENTRY_HEADER, preserving the required blank line.